### PR TITLE
Reducing EvidenceType to [SplitRead, ReadPair], adding lots of tests, support for unpaired data

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/sv/AlignedSegment.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/AlignedSegment.scala
@@ -176,14 +176,14 @@ object AlignedSegment extends LazyLogging {
       case (None     , _    ) => NoSegments
     }
 
-    if (r1Segments.isEmpty)
-      r2Segments
-    else if (r2Segments.isEmpty)
-      r1Segments
-    else
-      // Assume the library should be FR, reverse the R2 segments and flip their strand so that they're
-      // in the same order and orientation as R1 segments
-      mergeAlignedSegments(r1Segments=r1Segments, r2Segments=r2Segments.reverse.map(b => b.copy(positiveStrand = !b.positiveStrand)))
+    (r1Segments, r2Segments) match {
+      case (segs, IndexedSeq()) => segs
+      case (IndexedSeq(), segs) => segs
+      case (s1, s2) =>
+        // Assume the library should be FR, reverse the R2 segments and flip their strand so that they're
+        // in the same order and orientation as R1 segments
+        mergeAlignedSegments(r1Segments=r1Segments, r2Segments=r2Segments.reverse.map(b => b.copy(positiveStrand = !b.positiveStrand)))
+    }
   }
 
   /**
@@ -240,7 +240,7 @@ sealed trait SegmentOrigin extends EnumEntry {
   }
 }
 
-/** Enumeration for where a given [[AlignedSegment]] origintes. */
+/** Enumeration for where a given [[AlignedSegment]] originates. */
 object SegmentOrigin extends FgBioEnum[SegmentOrigin] {
   def values: IndexedSeq[SegmentOrigin] = findValues
   /** R1-only segment */

--- a/src/main/scala/com/fulcrumgenomics/sv/AlignedSegment.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/AlignedSegment.scala
@@ -165,15 +165,15 @@ object AlignedSegment extends LazyLogging {
     require(r1Primary.nonEmpty || r2Primary.nonEmpty, s"${template.name} did not have a primary R1 or R2 mapped.")
 
     val r1Segments = (r1Primary, template.r1Supplementals) match {
-      case (Some(pri), supps) if supps.isEmpty => IndexedSeq(AlignedSegment(pri))
-      case (Some(pri), supps)                  => segmentsFrom(pri, supps, minUniqueBasesToAdd)
-      case (None     , _    )                  => NoSegments
+      case (Some(pri), Seq()) => IndexedSeq(AlignedSegment(pri))
+      case (Some(pri), supps) => segmentsFrom(pri, supps, minUniqueBasesToAdd)
+      case (None     , _    ) => NoSegments
     }
 
     val r2Segments = (r2Primary, template.r2Supplementals) match {
-      case (Some(pri), supps) if supps.isEmpty => IndexedSeq(AlignedSegment(pri))
-      case (Some(pri), supps)                  => segmentsFrom(pri, supps, minUniqueBasesToAdd)
-      case (None     , _    )                  => NoSegments
+      case (Some(pri), Seq()) => IndexedSeq(AlignedSegment(pri))
+      case (Some(pri), supps) => segmentsFrom(pri, supps, minUniqueBasesToAdd)
+      case (None     , _    ) => NoSegments
     }
 
     if (r1Segments.isEmpty)

--- a/src/main/scala/com/fulcrumgenomics/sv/AlignedSegment.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/AlignedSegment.scala
@@ -169,21 +169,17 @@ object AlignedSegment extends LazyLogging {
     val r1Supps = template.r1Supplementals.iterator.filter(_.mapq >= minSupplementaryMappingQuality)
     val r2Supps = template.r2Supplementals.iterator.filter(_.mapq >= minSupplementaryMappingQuality)
 
-    if (r1Supps.isEmpty && r2Supps.isEmpty) {
-      IndexedSeq(AlignedSegment(r1), AlignedSegment(r2))
-    } else {
-      val r1Segments = if (r1Supps.isEmpty) IndexedSeq(AlignedSegment(r1)) else {
-        AlignedSegment.segmentsFrom(primary=r1, supplementals=r1Supps, minUniqueBasesToAdd=minUniqueBasesToAdd)
-      }
-      val r2Segments = if (r2Supps.isEmpty) IndexedSeq(AlignedSegment(r2)) else {
-        AlignedSegment.segmentsFrom(primary=r2, supplementals=r2Supps, minUniqueBasesToAdd=minUniqueBasesToAdd)
-          .reverse
-          .map(b => b.copy(positiveStrand = !b.positiveStrand))
-      }
-      // reverse the R2 segments as the first segments in R2 are last segments in the template when starting from the start
-      // of R1, also need to switch strand as we expect FR pair
-      mergeAlignedSegments(r1Segments=r1Segments, r2Segments=r2Segments)
+    val r1Segments = if (r1Supps.isEmpty) IndexedSeq(AlignedSegment(r1)) else {
+      AlignedSegment.segmentsFrom(primary=r1, supplementals=r1Supps, minUniqueBasesToAdd=minUniqueBasesToAdd)
     }
+
+    val r2Segments = if (r2Supps.isEmpty) IndexedSeq(AlignedSegment(r2)) else {
+      AlignedSegment.segmentsFrom(primary=r2, supplementals=r2Supps, minUniqueBasesToAdd=minUniqueBasesToAdd).reverse
+    }
+
+    // reverse the R2 segments as the first segments in R2 are last segments in the template when starting from the start
+    // of R1, also need to switch strand as we expect FR pair
+    mergeAlignedSegments(r1Segments=r1Segments, r2Segments=r2Segments.map(b => b.copy(positiveStrand = !b.positiveStrand)))
   }
 
   /**

--- a/src/main/scala/com/fulcrumgenomics/sv/EvidenceType.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/EvidenceType.scala
@@ -6,7 +6,7 @@ import enumeratum.EnumEntry
 
 import scala.collection.immutable
 
-/** An enumeration over types of SV evidence. */
+/** An enumeration over types of breakpoint evidence. */
 object EvidenceType extends FgBioEnum[EvidenceType] {
   /** Evidence of the breakpoint was observed within aligned segments of a single read with split alignments. */
   case object SplitRead extends EvidenceType

--- a/src/main/scala/com/fulcrumgenomics/sv/EvidenceType.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/EvidenceType.scala
@@ -8,21 +8,11 @@ import scala.collection.immutable
 
 /** An enumeration over types of SV evidence. */
 object EvidenceType extends FgBioEnum[EvidenceType] {
+  /** Evidence of the breakpoint was observed within aligned segments of a single read with split alignments. */
+  case object SplitRead extends EvidenceType
 
-  /** Evidence from one end of a read mapping to a different contig than the other. */
-  case object ReadPairInterContig extends EvidenceType
-  /** Evidence from one end of a read mapping to a the same contig as the other, but too far apart. */
-  case object ReadPairIntraContig extends EvidenceType
-  /** Evidence from a reverse-forward read pair orientation. */
-  case object ReadPairReverseForward extends EvidenceType
-  /** Evidence from a tandem read pair orientation. */
-  case object ReadPairTandem extends EvidenceType
-  /** Evidence from a split read mapping where adjacent segments map to different contigs. */
-  case object SplitReadInterContig extends EvidenceType
-  /** Evidence from a split read mapping where adjacent segments map to the same contig, but too far apart. */
-  case object SplitReadIntraContig extends EvidenceType
-  /** Evidence from a split read mapping where adjacent segments map to opposite genomic strands. */
-  case object SplitReadOppositeStrand extends EvidenceType
+  /** Evidence of the breakpoint was only observed _between_ reads in a read pair. */
+  case object ReadPair extends EvidenceType
 
   override val values: immutable.IndexedSeq[EvidenceType] = findValues
 }

--- a/src/main/scala/com/fulcrumgenomics/sv/tools/SvPileup.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/tools/SvPileup.scala
@@ -179,8 +179,8 @@ object SvPileup extends LazyLogging {
 
     if (!r1PrimaryOk && !r2PrimaryOk) None else Some(
       Template(
-        r1 = if (r1PrimaryOk) t.r1 else None,
-        r2 = if (r2PrimaryOk) t.r2 else None,
+        r1              = if (r1PrimaryOk) t.r1 else None,
+        r2              = if (r2PrimaryOk) t.r2 else None,
         r1Supplementals = if (r1PrimaryOk) t.r1Supplementals.filter(_.mapq >= minSupplementaryMapq) else Nil,
         r2Supplementals = if (r2PrimaryOk) t.r2Supplementals.filter(_.mapq >= minSupplementaryMapq) else Nil,
       )
@@ -201,7 +201,7 @@ object SvPileup extends LazyLogging {
                       maxReadPairInnerDistance: Int,
                       minUniqueBasesToAdd: Int,
                      ): IndexedSeq[BreakpointEvidence] = {
-    val segments = AlignedSegment.segmentsFrom(template, minUniqueBasesToAdd = minUniqueBasesToAdd)
+    val segments = AlignedSegment.segmentsFrom(template, minUniqueBasesToAdd=minUniqueBasesToAdd)
 
     segments.length match {
       case 0 | 1 =>
@@ -211,11 +211,9 @@ object SvPileup extends LazyLogging {
         val bp = findBreakpoint(segments.head, segments.last, maxWithinReadDistance, maxReadPairInnerDistance)
         if (bp.isEmpty) NoBreakpoints else bp.toIndexedSeq
       case _     =>
-        val builder = IndexedSeq.newBuilder[BreakpointEvidence]
-        segments.iterator.sliding(2).foreach { case Seq(seg1, seg2) =>
-          findBreakpoint(seg1, seg2, maxWithinReadDistance, maxReadPairInnerDistance).foreach(builder += _)
-        }
-        builder.result()
+        segments.iterator.sliding(2).flatMap { case Seq(seg1, seg2) =>
+          findBreakpoint(seg1, seg2, maxWithinReadDistance, maxReadPairInnerDistance)
+        }.toIndexedSeq
     }
   }
 
@@ -236,7 +234,7 @@ object SvPileup extends LazyLogging {
     }
   }
 
-  /** Determines if two segments are evidence of breakpoint joining two different contigs.
+  /** Determines if two segments are evidence of a breakpoint joining two different contigs.
    *
    * @param seg1 the first alignment segment
    * @param seg2 the second alignment segment

--- a/src/main/scala/com/fulcrumgenomics/sv/tools/SvPileup.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/tools/SvPileup.scala
@@ -247,7 +247,7 @@ object SvPileup extends LazyLogging {
 
   /** Determines if the two segments are provide evidence of a breakpoint joining two different regions from
    * the same contig. Returns true if:
-   *   - the two segments overlap (implying some kind of duplication)
+   *   - the two segments overlap (implying some kind of duplication) (note overlapping reads will get a merged seg)
    *   - the strand of the two segments differ (implying an inversion or other rearrangement)
    *   - the second segment is before the first segment on the genome
    *   - the distance between the two segments is larger than the maximum allowed (likely a deletion)
@@ -267,9 +267,10 @@ object SvPileup extends LazyLogging {
     // the segments should all come out on the same strand.  Therefore any difference in strand is odd.  In addition
     // any segment that "moves backwards" down the genome is odd, as genome position and read position should increase
     // together.
-    seg1.positiveStrand != seg2.positiveStrand ||
-      (seg1.positiveStrand && seg2.range.start < seg1.range.end) ||
-      (!seg1.positiveStrand && seg1.range.start < seg2.range.start) || {
+    if (seg1.positiveStrand != seg2.positiveStrand) true
+    else if (seg1.positiveStrand && seg2.range.start < seg1.range.end) true
+    else if (!seg1.positiveStrand && seg1.range.start < seg2.range.start) true
+    else {
       val maxDistance = if (seg1.origin.isInterRead(seg2.origin)) maxBetweenReadDistance else maxWithinReadDistance
 
       val innerDistance = {

--- a/src/test/scala/com/fulcrumgenomics/sv/AlignedSegmentTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/sv/AlignedSegmentTest.scala
@@ -72,7 +72,7 @@ class AlignedSegmentTest extends UnitSpec {
     )
   }
 
-  "AlignmentBloc.segmentsFrom" should "create segments from a primary and one supplementals" in {
+  "AlignedSegment.segmentsFrom" should "create segments from a primary and one supplementals" in {
     val dummyRange = GenomicRange(refIndex=0, start=1, end=100)
 
     val primary = AlignedSegment(

--- a/src/test/scala/com/fulcrumgenomics/sv/AlignedSegmentTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/sv/AlignedSegmentTest.scala
@@ -84,17 +84,17 @@ class AlignedSegmentTest extends UnitSpec {
 
     // Keep both
     AlignedSegment.segmentsFrom(
-      primary=primary, supplementals=Iterator(supplemental), readLength=100, minUniqueBasesToAdd=50
+      primary=primary, supplementals=Seq(supplemental), readLength=100, minUniqueBasesToAdd=50
     ) should contain theSameElementsInOrderAs IndexedSeq(primary, supplemental)
 
     // Keep only the primary, as the supplemental doesn't add enough new bases
     AlignedSegment.segmentsFrom(
-      primary=primary, supplementals=Iterator(supplemental), readLength=100, minUniqueBasesToAdd=51
+      primary=primary, supplementals=Seq(supplemental), readLength=100, minUniqueBasesToAdd=51
     ) should contain theSameElementsInOrderAs IndexedSeq(primary)
 
     // Keep one supplemental
     AlignedSegment.segmentsFrom(
-      primary=primary, supplementals=Iterator(supplemental, supplemental), readLength=100, minUniqueBasesToAdd=50
+      primary=primary, supplementals=Seq(supplemental, supplemental), readLength=100, minUniqueBasesToAdd=50
     ) should contain theSameElementsInOrderAs IndexedSeq(primary, supplemental)
 
     // A more complicated test case
@@ -111,7 +111,7 @@ class AlignedSegmentTest extends UnitSpec {
     // Will not be added, as we have zero new bases
     val s6 = AlignedSegment(origin=ReadOne, readStart=91, readEnd=100, positiveStrand=true, cigar=Cigar.empty, range=dummyRange)
     AlignedSegment.segmentsFrom(
-      primary=primary, supplementals=Iterator(s1, s2, s3, s4, s5, s6), readLength=100, minUniqueBasesToAdd=10
+      primary=primary, supplementals=Seq(s1, s2, s3, s4, s5, s6), readLength=100, minUniqueBasesToAdd=10
     ) should contain theSameElementsInOrderAs IndexedSeq(primary, s1, s3, s5)
   }
 

--- a/src/test/scala/com/fulcrumgenomics/sv/EvidenceTypeTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/sv/EvidenceTypeTest.scala
@@ -1,9 +1,9 @@
 package com.fulcrumgenomics.sv
 
-import com.fulcrumgenomics.sv.EvidenceType.SplitReadOppositeStrand
+import com.fulcrumgenomics.sv.EvidenceType.SplitRead
 
 class EvidenceTypeTest extends UnitSpec {
   "EvidenceType.snakeName" should "convert to the name to snake-case" in {
-    SplitReadOppositeStrand.snakeName shouldBe "split_read_opposite_strand"
+    SplitRead.snakeName shouldBe "split_read"
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/sv/tools/SvPileupTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/sv/tools/SvPileupTest.scala
@@ -247,4 +247,17 @@ class SvPileupTest extends UnitSpec {
       bp(SplitRead, "chr2", 500, Minus, "chr3", 900, Plus),
     )
   }
+
+  it should "call a breakpoint from a single-end split read with no mate" in {
+    val r1Half1 = r("chr1", 100, Plus,  r=1, cigar="50M50S", supp=false)
+    val r1Half2 = r("chr7", 800, Plus,  r=1, cigar="50S50M", supp=true)
+    Seq(r1Half1, r1Half2).foreach { r =>
+      r.firstOfPair  = false
+      r.secondOfPair = false
+      r.paired       = false
+    }
+
+    val expected = IndexedSeq(bp(SplitRead, "chr1", 149, Plus, "chr7", 800, Plus))
+    call(t(r1Half1, r1Half2)) should contain theSameElementsInOrderAs expected
+  }
 }

--- a/src/test/scala/com/fulcrumgenomics/sv/tools/SvPileupTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/sv/tools/SvPileupTest.scala
@@ -157,6 +157,14 @@ class SvPileupTest extends UnitSpec {
     call(template) should contain theSameElementsInOrderAs IndexedSeq.empty
   }
 
+  it should "not call a breakpoint from an FR pair with overlapping reads" in {
+    val template = t(
+      r("chr1", 100, Plus,  r=1, cigar="100M", supp=false),
+      r("chr1", 150, Minus, r=2, cigar="100M", supp=false),
+    )
+    call(template) should contain theSameElementsInOrderAs IndexedSeq.empty
+  }
+
   it should "call a breakpoint from a tandem read pair" in {
     val bps = call(t(
       r("chr1", 100, Plus, r=1, cigar="100M", supp=false),

--- a/src/test/scala/com/fulcrumgenomics/sv/tools/SvPileupTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/sv/tools/SvPileupTest.scala
@@ -1,134 +1,100 @@
 package com.fulcrumgenomics.sv.tools
 
 import com.fulcrumgenomics.alignment.Cigar
-import com.fulcrumgenomics.sv.EvidenceType._
 import com.fulcrumgenomics.sv.SegmentOrigin.{Both, ReadOne, ReadTwo}
 import com.fulcrumgenomics.sv._
 
 class SvPileupTest extends UnitSpec {
-  private def fromRangeOnly(refIndex: Int, start: Int, end: Int, origin: SegmentOrigin = ReadOne): AlignedSegment = AlignedSegment(
-    origin=origin,
-    readStart=1, readEnd=100, positiveStrand=true, cigar=Cigar("100M"),
-    range=GenomicRange(refIndex=refIndex, start=start, end=end)
-  )
+  private def fromRangeOnly(refIndex: Int, start: Int, end: Int, origin: SegmentOrigin = ReadOne, positive: Boolean = true): AlignedSegment =
+    AlignedSegment(
+      origin=origin,
+      readStart=1, readEnd=100, positiveStrand=positive, cigar=Cigar("100M"),
+      range=GenomicRange(refIndex=refIndex, start=start, end=end)
+    )
 
-  "SvPileup.determineInterContigBreakpoint" should "determine if two alignment segments are an inter-contig breakpoint" in {
+  "SvPileup.isInterContigBreakpoint" should "is if two alignment segments are an inter-contig breakpoint" in {
     val chr1 = fromRangeOnly(refIndex=0, start=1, end=100)
     val chr2 = fromRangeOnly(refIndex=1, start=1, end=100)
 
     // Same contig
-    SvPileup.determineInterContigBreakpoint(seg1=chr1, seg2=chr1).isEmpty shouldBe true
+    SvPileup.isInterContigBreakpoint(seg1=chr1, seg2=chr1) shouldBe false
 
     // Different contig
-    SvPileup.determineInterContigBreakpoint(seg1=chr1, seg2=chr2).value shouldBe BreakpointEvidence(
-      chr1, chr2, SplitReadInterContig
-    )
-    SvPileup.determineInterContigBreakpoint(seg1=chr2, seg2=chr1).value shouldBe BreakpointEvidence(
-      chr2, chr1, SplitReadInterContig
-    )
-    SvPileup.determineInterContigBreakpoint(seg1=chr1, seg2=chr2.copy(origin=ReadTwo)).value shouldBe BreakpointEvidence(
-      chr1, chr2.copy(origin=ReadTwo), ReadPairInterContig
-    )
-    SvPileup.determineInterContigBreakpoint(seg1=chr2.copy(origin=ReadTwo), seg2=chr1).value shouldBe BreakpointEvidence(
-      chr2.copy(origin=ReadTwo), chr1, ReadPairInterContig
-    )
-    SvPileup.determineInterContigBreakpoint(seg1=chr1, seg2=chr2.copy(origin=Both)).value shouldBe BreakpointEvidence(
-      chr1, chr2.copy(origin=Both), ReadPairInterContig
-    )
-    SvPileup.determineInterContigBreakpoint(seg1=chr2.copy(origin=Both), seg2=chr1).value shouldBe BreakpointEvidence(
-      chr2.copy(origin=Both), chr1, ReadPairInterContig
-    )
-    SvPileup.determineInterContigBreakpoint(seg1=chr1.copy(origin=Both), seg2=chr2.copy(origin=Both)).value shouldBe BreakpointEvidence(
-      chr1.copy(origin=Both), chr2.copy(origin=Both), ReadPairInterContig
-    )
-    SvPileup.determineInterContigBreakpoint(seg1=chr2.copy(origin=Both), seg2=chr1.copy(origin=Both)).value shouldBe BreakpointEvidence(
-      chr2.copy(origin=Both), chr1.copy(origin=Both), ReadPairInterContig
-    )
+    SvPileup.isInterContigBreakpoint(seg1=chr1, seg2=chr2) shouldBe true
+    SvPileup.isInterContigBreakpoint(seg1=chr2, seg2=chr1) shouldBe true
+    SvPileup.isInterContigBreakpoint(seg1=chr1, seg2=chr2.copy(origin=ReadTwo)) shouldBe true
+    SvPileup.isInterContigBreakpoint(seg1=chr2.copy(origin=ReadTwo), seg2=chr1) shouldBe true
+    SvPileup.isInterContigBreakpoint(seg1=chr1, seg2=chr2.copy(origin=Both)) shouldBe true
+    SvPileup.isInterContigBreakpoint(seg1=chr2.copy(origin=Both), seg2=chr1) shouldBe true
+    SvPileup.isInterContigBreakpoint(seg1=chr1.copy(origin=Both), seg2=chr2.copy(origin=Both)) shouldBe true
+    SvPileup.isInterContigBreakpoint(seg1=chr2.copy(origin=Both), seg2=chr1.copy(origin=Both)) shouldBe true
   }
 
-  "SvPileup.determineOddPairOrientation" should "determine if two alignment segments have an odd pair orientation" in {
+  "SvPileup.isIntraContigBreakpoint" should "identify where two segments are not moving up the genome within the defined spacing" in {
     val earlier = fromRangeOnly(refIndex=1, start=1, end=100)
     val overlap = fromRangeOnly(refIndex=1, start=50, end=150)
     val later   = fromRangeOnly(refIndex=1, start=150, end=200)
 
-    // same segment
-    SvPileup.determineIntraContigBreakpoint(seg1=earlier, seg2=earlier, maxWithinReadDistance=0, maxBetweenReadDistance=0).isEmpty shouldBe true
+    // It has to be recalled that this test is done _after_ overlapping segments for R1 and R2 have been merged so
+    // any overlapping segments or jumping backwards between segments is indicative of a breakpoint
 
-    // overlapping segments
-    SvPileup.determineIntraContigBreakpoint(seg1=earlier, seg2=overlap, maxWithinReadDistance=0, maxBetweenReadDistance=0).isEmpty shouldBe true
+    // What you might get from a read pair with a gap between the two reads
+    SvPileup.isIntraContigBreakpoint(seg1=earlier, seg2=later.copy(origin=ReadTwo), maxWithinReadDistance=5, maxBetweenReadDistance=150) shouldBe false
 
-    // non-overlapping segments
-    SvPileup.determineIntraContigBreakpoint(seg1=earlier, seg2=later, maxWithinReadDistance=49, maxBetweenReadDistance=49).value shouldBe BreakpointEvidence(
-      earlier, later, SplitReadIntraContig
-    )
-    SvPileup.determineIntraContigBreakpoint(seg1=earlier, seg2=later.copy(origin=ReadTwo), maxWithinReadDistance=49, maxBetweenReadDistance=49).value shouldBe BreakpointEvidence(
-      earlier, later.copy(origin=ReadTwo), ReadPairIntraContig
-    )
-    SvPileup.determineIntraContigBreakpoint(seg1=earlier, seg2=later.copy(origin=Both), maxWithinReadDistance=49, maxBetweenReadDistance=49).value shouldBe BreakpointEvidence(
-      earlier, later.copy(origin=Both), SplitReadIntraContig
-    )
-    SvPileup.determineIntraContigBreakpoint(seg1=earlier.copy(origin=Both), seg2=later, maxWithinReadDistance=49, maxBetweenReadDistance=49).value shouldBe BreakpointEvidence(
-      earlier.copy(origin=Both), later, SplitReadIntraContig
-    )
-    SvPileup.determineIntraContigBreakpoint(seg1=earlier.copy(origin=Both), seg2=later.copy(origin=Both), maxWithinReadDistance=49, maxBetweenReadDistance=49).value shouldBe BreakpointEvidence(
-      earlier.copy(origin=Both), later.copy(origin=Both), SplitReadIntraContig
-    )
-    SvPileup.determineIntraContigBreakpoint(seg1=earlier, seg2=later, maxWithinReadDistance=50, maxBetweenReadDistance=50).isEmpty shouldBe true
+    // same segment but jumping backwards
+    SvPileup.isIntraContigBreakpoint(seg1=earlier, seg2=earlier, maxWithinReadDistance=5, maxBetweenReadDistance=150) shouldBe true
+
+    // overlapping segments but still jumping backwards
+    SvPileup.isIntraContigBreakpoint(seg1=earlier, seg2=overlap, maxWithinReadDistance=5, maxBetweenReadDistance=150) shouldBe true
+
+    // non-overlapping segments from the same read, testing various values for maxWithinReadDistance
+    // Note that the inner distance between two blocks is defined as `later.start - earlier.end`, so for
+    // this case that is 150-100 = 50, so a breakpoint should be called when the maxWithinReadDistance < 50.
+    SvPileup.isIntraContigBreakpoint(seg1=earlier, seg2=later, maxWithinReadDistance= 5, maxBetweenReadDistance=150) shouldBe true
+    SvPileup.isIntraContigBreakpoint(seg1=earlier, seg2=later, maxWithinReadDistance=25, maxBetweenReadDistance=150) shouldBe true
+    SvPileup.isIntraContigBreakpoint(seg1=earlier, seg2=later, maxWithinReadDistance=48, maxBetweenReadDistance=150) shouldBe true
+    SvPileup.isIntraContigBreakpoint(seg1=earlier, seg2=later, maxWithinReadDistance=49, maxBetweenReadDistance=150) shouldBe true
+    SvPileup.isIntraContigBreakpoint(seg1=earlier, seg2=later, maxWithinReadDistance=50, maxBetweenReadDistance=150) shouldBe false
+    SvPileup.isIntraContigBreakpoint(seg1=earlier, seg2=later, maxWithinReadDistance=51, maxBetweenReadDistance=150) shouldBe false
+
+    // non-overlapping segments where the later segment is "both" so indicates a split read breakpoint
+    SvPileup.isIntraContigBreakpoint(seg1=earlier, seg2=later.copy(origin=Both), maxWithinReadDistance= 5, maxBetweenReadDistance=150) shouldBe true
+    SvPileup.isIntraContigBreakpoint(seg1=earlier, seg2=later.copy(origin=Both), maxWithinReadDistance=25, maxBetweenReadDistance=150) shouldBe true
+    SvPileup.isIntraContigBreakpoint(seg1=earlier, seg2=later.copy(origin=Both), maxWithinReadDistance=49, maxBetweenReadDistance=150) shouldBe true
+    SvPileup.isIntraContigBreakpoint(seg1=earlier, seg2=later.copy(origin=Both), maxWithinReadDistance=75, maxBetweenReadDistance=150) shouldBe false
+
+    // non-overlapping segments where the later segment is "Read2" so between read distance should be used
+    SvPileup.isIntraContigBreakpoint(seg1=earlier, seg2=later.copy(origin=ReadTwo), maxWithinReadDistance=5, maxBetweenReadDistance=5 ) shouldBe true
+    SvPileup.isIntraContigBreakpoint(seg1=earlier, seg2=later.copy(origin=ReadTwo), maxWithinReadDistance=5, maxBetweenReadDistance=25) shouldBe true
+    SvPileup.isIntraContigBreakpoint(seg1=earlier, seg2=later.copy(origin=ReadTwo), maxWithinReadDistance=5, maxBetweenReadDistance=49) shouldBe true
+    SvPileup.isIntraContigBreakpoint(seg1=earlier, seg2=later.copy(origin=ReadTwo), maxWithinReadDistance=5, maxBetweenReadDistance=75) shouldBe false
   }
 
-  "SvPileup.determineOddPairOrientation" should "determine if two alignment segments have an odd read-pair orientation" in {
-    val r1Forward = fromRangeOnly(refIndex=1, start=1, end=100).copy(positiveStrand=true)
-    val r1Reverse = fromRangeOnly(refIndex=1, start=100, end=200).copy(positiveStrand=false)
-    val r2Forward = fromRangeOnly(refIndex=1, start=1, end=100).copy(positiveStrand=true, origin=ReadTwo)
-    val r2Reverse = fromRangeOnly(refIndex=1, start=100, end=200).copy(positiveStrand=false, origin=ReadTwo)
-    val bothForward = fromRangeOnly(refIndex=1, start=1, end=100).copy(positiveStrand=true, origin=Both)
-    val bothReverse = fromRangeOnly(refIndex=1, start=1, end=200).copy(positiveStrand=false, origin=Both)
+  "SvPileup.isIntraContigBreakpoint" should "identify when two segments flip strand" in {
+    // By the time we're in segment space, all segments from a well-formed FR read pair should
+    // share the same strand, so only when strands differ should a breakpoint be called
 
+    val f1 = fromRangeOnly(refIndex=1, start=1,   end=99)
+    val f2 = fromRangeOnly(refIndex=1, start=200, end=299)
+    val r1 = f1.copy(positiveStrand=false)
+    val r2 = f2.copy(positiveStrand=false)
 
-    // read pairs expect to be FR, so no breakpoint
-    SvPileup.determineOddPairOrientation(seg1=r1Forward, seg2=r2Reverse).isEmpty shouldBe true
-    SvPileup.determineOddPairOrientation(seg1=r2Forward, seg2=r1Reverse).isEmpty shouldBe true
-    SvPileup.determineOddPairOrientation(seg1=r1Reverse, seg2=r2Forward).isEmpty shouldBe true
-    SvPileup.determineOddPairOrientation(seg1=r2Reverse, seg2=r1Forward).isEmpty shouldBe true
+    // Simple tests that should not call breakpoints
+    SvPileup.isIntraContigBreakpoint(f1, f2, maxWithinReadDistance=500, maxBetweenReadDistance=500) shouldBe false
+    SvPileup.isIntraContigBreakpoint(r2, r1, maxWithinReadDistance=500, maxBetweenReadDistance=500) shouldBe false
 
-    // split pairs expect to be FF or RR, so no breakpoint
-    SvPileup.determineOddPairOrientation(seg1=r1Forward, seg2=r1Forward).isEmpty shouldBe true
-    SvPileup.determineOddPairOrientation(seg1=r1Reverse, seg2=r1Reverse).isEmpty shouldBe true
+    // Now what if we make them different reads
+    SvPileup.isIntraContigBreakpoint(f1, f2.copy(origin=ReadTwo), maxWithinReadDistance=500, maxBetweenReadDistance=500) shouldBe false
+    SvPileup.isIntraContigBreakpoint(r2, r1.copy(origin=ReadTwo), maxWithinReadDistance=500, maxBetweenReadDistance=500) shouldBe false
 
-    // read pairs should be odd if RF or tandem
-    SvPileup.determineOddPairOrientation(seg1=r1Forward, seg2=r2Forward).value shouldBe BreakpointEvidence(
-      r1Forward, r2Forward, ReadPairTandem
-    )
-    SvPileup.determineOddPairOrientation(seg1=r1Reverse, seg2=r2Reverse).value shouldBe BreakpointEvidence(
-      r1Reverse, r2Reverse, ReadPairTandem
-    )
-    // NB: bothForward can be treated as r2Forward, so tandem
-    SvPileup.determineOddPairOrientation(seg1=r1Forward, seg2=bothForward).value shouldBe BreakpointEvidence(
-      r1Forward, bothForward, ReadPairTandem
-    )
-    // NB: bothReverse can be treated as r2Reverse, so tandem
-    SvPileup.determineOddPairOrientation(seg1=r1Reverse, seg2=bothReverse).value shouldBe BreakpointEvidence(
-      r1Reverse, bothReverse, ReadPairTandem
-    )
-    // NB: both* can be treated as R1/R2, so tandem
-    SvPileup.determineOddPairOrientation(seg1=bothForward, seg2=bothForward).value shouldBe BreakpointEvidence(
-      bothForward, bothForward, ReadPairTandem
-    )
-    // NB: both* can be treated as R1/R2, so tandem
-    SvPileup.determineOddPairOrientation(seg1=bothReverse, seg2=bothReverse).value shouldBe BreakpointEvidence(
-      bothReverse, bothReverse, ReadPairTandem
-    )
-
-    // split reads should be odd if RF or FR
-    Seq(
-      (r1Forward, r1Reverse),
-      (r1Reverse, r1Forward),
-      (r2Forward, r2Reverse),
-      (r2Reverse, r2Forward),
-    ).foreach { case (seg1, seg2) =>
-      SvPileup.determineOddPairOrientation(seg1=seg1, seg2=seg2).value shouldBe BreakpointEvidence(
-        seg1, seg2, SplitReadOppositeStrand
-      )
-    }
+    // But any combination on different strands should yield a breakpoint
+    SvPileup.isIntraContigBreakpoint(f1, r1, maxWithinReadDistance=500, maxBetweenReadDistance=500) shouldBe true
+    SvPileup.isIntraContigBreakpoint(f1, r2, maxWithinReadDistance=500, maxBetweenReadDistance=500) shouldBe true
+    SvPileup.isIntraContigBreakpoint(f2, r1, maxWithinReadDistance=500, maxBetweenReadDistance=500) shouldBe true
+    SvPileup.isIntraContigBreakpoint(f2, r2, maxWithinReadDistance=500, maxBetweenReadDistance=500) shouldBe true
+    SvPileup.isIntraContigBreakpoint(r1, f1, maxWithinReadDistance=500, maxBetweenReadDistance=500) shouldBe true
+    SvPileup.isIntraContigBreakpoint(r1, f2, maxWithinReadDistance=500, maxBetweenReadDistance=500) shouldBe true
+    SvPileup.isIntraContigBreakpoint(r2, f1, maxWithinReadDistance=500, maxBetweenReadDistance=500) shouldBe true
+    SvPileup.isIntraContigBreakpoint(r2, f2, maxWithinReadDistance=500, maxBetweenReadDistance=500) shouldBe true
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/sv/tools/SvPileupTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/sv/tools/SvPileupTest.scala
@@ -1,8 +1,12 @@
 package com.fulcrumgenomics.sv.tools
 
 import com.fulcrumgenomics.alignment.Cigar
+import com.fulcrumgenomics.bam.Template
+import com.fulcrumgenomics.bam.api.SamRecord
+import com.fulcrumgenomics.sv.EvidenceType.{ReadPair, SplitRead}
 import com.fulcrumgenomics.sv.SegmentOrigin.{Both, ReadOne, ReadTwo}
 import com.fulcrumgenomics.sv._
+import com.fulcrumgenomics.testing.SamBuilder
 
 class SvPileupTest extends UnitSpec {
   private def fromRangeOnly(refIndex: Int, start: Int, end: Int, origin: SegmentOrigin = ReadOne, positive: Boolean = true): AlignedSegment =
@@ -96,5 +100,151 @@ class SvPileupTest extends UnitSpec {
     SvPileup.isIntraContigBreakpoint(r1, f2, maxWithinReadDistance=500, maxBetweenReadDistance=500) shouldBe true
     SvPileup.isIntraContigBreakpoint(r2, f1, maxWithinReadDistance=500, maxBetweenReadDistance=500) shouldBe true
     SvPileup.isIntraContigBreakpoint(r2, f2, maxWithinReadDistance=500, maxBetweenReadDistance=500) shouldBe true
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Objects and functions used in testing findBreakpoint()
+  //////////////////////////////////////////////////////////////////////////////
+  private val builder = new SamBuilder(readLength=100)
+  import SamBuilder.{Minus, Plus, Strand}
+
+  /** Construct a read/rec with the information necessary for breakpoint detection. */
+  def r(chrom: String, pos: Int, strand: SamBuilder.Strand, r: Int, cigar: String, supp: Boolean): SamRecord = {
+    require(r == 1 || r == 2)
+    val rec = builder.addFrag(contig=builder.dict(chrom).index, start=pos, strand=strand, cigar=cigar).get
+    rec.supplementary = supp
+    rec.paired = true
+    rec.firstOfPair = r == 1
+    rec.secondOfPair = r == 2
+    rec
+  }
+
+  /** Construct a Template from one or more SamRecords. */
+  def t(recs: SamRecord*): Template = Template(recs.iterator.tapEach(_.name = "q1"))
+
+  /** Call breakpoints from a template. */
+  def call(t: Template): IndexedSeq[BreakpointEvidence] =
+    SvPileup.findBreakpoints(
+      template                       = t,
+      maxWithinReadDistance          = 5,
+      maxReadPairInnerDistance       = 1000,
+      minSupplementaryMappingQuality = 0,
+      minUniqueBasesToAdd            = 10
+    )
+
+  /** Short hand for constructing a BreakpointEvidence. */
+  def bp(ev: EvidenceType, lChrom: String, lPos: Int, lStrand: Strand, rChrom: String, rPos: Int, rStrand: Strand): BreakpointEvidence =
+    BreakpointEvidence(
+      Breakpoint(
+        leftRefIndex  = builder.dict(lChrom).index,
+        leftPos       = lPos,
+        leftPositive  = lStrand == Plus,
+        rightRefIndex = builder.dict(rChrom).index,
+        rightPos      = rPos,
+        rightPositive = rStrand == Plus),
+      ev)
+
+
+
+  "SvPileup.findBreakpoints(template)" should "find nothing interesting in an FR read pair with no supplementaries" in {
+    val template = t(
+      r("chr1", 100, Plus,  r=1, cigar="100M", supp=false),
+      r("chr1", 250, Minus, r=2, cigar="100M", supp=false),
+    )
+    call(template) should contain theSameElementsInOrderAs IndexedSeq.empty
+  }
+
+  it should "call a breakpoint from a tandem read pair" in {
+    val bps = call(t(
+      r("chr1", 100, Plus, r=1, cigar="100M", supp=false),
+      r("chr1", 250, Plus, r=2, cigar="100M", supp=false),
+    ))
+
+    bps should contain theSameElementsInOrderAs IndexedSeq(
+      bp(ReadPair, "chr1", 199, Plus, "chr1", 349, Minus)
+    )
+  }
+
+  it should "call a breakpoint from an RF read pair" in {
+    val bps = call(t(
+      r("chr1", 100, Minus, r=1, cigar="100M", supp=false),
+      r("chr1", 250, Plus,  r=2, cigar="100M", supp=false),
+    ))
+
+    bps should contain theSameElementsInOrderAs IndexedSeq(
+      bp(ReadPair, "chr1", 100, Minus, "chr1", 349, Minus)
+    )
+  }
+
+  it should "call a breakpoint from an FR read pair with a large insert size" in {
+    val bps = call(t(
+      r("chr1", 100,   Plus,   r=1, cigar="100M", supp=false),
+      r("chr1", 10000, Minus,  r=2, cigar="100M", supp=false),
+    ))
+
+    bps should contain theSameElementsInOrderAs IndexedSeq(
+      bp(ReadPair, "chr1", 199, Plus, "chr1", 10000, Plus)
+    )
+  }
+
+  it should "call a breakpoint from an FR read pair across chromosomes" in {
+    val bps = call(t(
+      r("chr1", 100, Plus,  r=1, cigar="100M", supp=false),
+      r("chr2", 300, Minus, r=2, cigar="100M", supp=false),
+    ))
+
+    bps should contain theSameElementsInOrderAs IndexedSeq(
+      bp(ReadPair, "chr1", 199, Plus, "chr2", 300, Plus)
+    )
+  }
+
+  it should "call a breakpoint with one or more split reads" in {
+    // A set of reads where each read (r1/r2) is either completely aligned near one side of
+    // breakpoint, or the read is split-read aligned across the breakpoint.
+    val fullR1  = r("chr1",   1, Plus,  r=1, cigar="100M",   supp=false)
+    val r1Half1 = r("chr1", 100, Plus,  r=1, cigar="50M50S", supp=false)
+    val r1Half2 = r("chr7", 800, Plus,  r=1, cigar="50S50M", supp=true)
+
+    val fullR2  = r("chr7", 850, Minus, r=2, cigar="100M",   supp=false)
+    val r2Half1 = r("chr7", 800, Minus, r=2, cigar="30S70M", supp=false)
+    val r2Half2 = r("chr1", 120, Minus, r=2, cigar="30M70S", supp=true)
+
+    val expected = IndexedSeq(bp(SplitRead, "chr1", 149, Plus, "chr7", 800, Plus))
+    call(t(r1Half2, r1Half1, fullR2))           should contain theSameElementsInOrderAs expected
+    call(t(fullR1,  r2Half1, r2Half2))          should contain theSameElementsInOrderAs expected
+    call(t(r1Half1, r1Half2, r2Half1, r2Half2)) should contain theSameElementsInOrderAs expected
+  }
+
+  it should "only call one breakpoint where R1 and R2 have slightly different split-read support" in {
+    // If there is repetitive sequence at the breakpoint the aligner split r1 and r2 slightly
+    // differently on each side - make sure we don't generate two breakpoints in that case
+    val bps = call(t(
+      // Read 1 supports a breakpoint at chr1:149F>chr7:800F
+      r("chr1", 100, Plus,  r=1, cigar="50M50S", supp=false),
+      r("chr7", 800, Plus,  r=1, cigar="50S50M", supp=true),
+      // Read 1 supports a breakpoint at chr1:151F>chr7:802F
+      r("chr7", 802, Minus, r=2, cigar="30S70M", supp=false),
+      r("chr1", 122, Minus, r=2, cigar="30M70S", supp=true)
+    ))
+
+    // The one breakpoint that does come out is not ideal in this case, but maybe that's ok?
+    // I think ideally it would call chr1:149F>chr7:800F or chr1:151F>chr7:802F not chr1:151F>chr7:800F
+    val expected = IndexedSeq(bp(SplitRead, "chr1", 151, Plus, "chr7", 800, Plus))
+    bps should contain theSameElementsInOrderAs expected
+  }
+
+  it should "call more than one breakpoint from a read pair that supports more than one" in {
+    val bps = call(t(
+      r("chr1", 100, Plus,  r=1, cigar="30M70S",    supp=false),
+      r("chr2", 500, Minus, r=1, cigar="30S40M30S", supp=true),
+      r("chr3", 900, Plus,  r=1, cigar="70S30M",    supp=true),
+
+      r("chr3", 1200, Minus, r=2, cigar="100M", supp=false),
+    ))
+
+    bps should contain theSameElementsInOrderAs IndexedSeq(
+      bp(SplitRead, "chr1", 129, Plus,  "chr2", 539, Minus),
+      bp(SplitRead, "chr2", 500, Minus, "chr3", 900, Plus),
+    )
   }
 }


### PR DESCRIPTION
This PR got a it bigger than I had originally intended.  There are a few major changes rolled into one PR:

1. Reducing `EvidenceType` down to just `SplitRead` and `ReadPair`, and everything that follows from that.  As part of this I restructured the `determine*` methods in SvPileup to be called `is*` and return booleans, as the construction of the `BreakpointEvidence` is the same in all cases and can be pulled up into the calling method.  I also collapsed `isIntraContig` and `isOddPair` because a) they've gotten simpler and b) I kept confusing myself as to which method should identify which kind of breakpoint where the ends are on the same contig (e.g. where does detection of the following belong: seg1=chr1:500:F, seg2=chr1:200:F`?)
2. While doing this I noticed what I think is a large inconsistency in how `AlignedSegment` extraction was working, and a related bug in how "odd pair" detection was working.  The short version is that depending on the branch you took, based on the number of supplementary alignments, R2 segments were sometimes strand flipped and sometimes not, making accurate odd-pair detection impossible.  And the odd-pair detection that was there relied on the segments from R2 _not_ being strand flipped.  I've cleaned this up so that R2 records are always strand flipped (except, in 4 below)
3. This made me really nervous so I wrote a whole bunch of tests that start at `findBreakpoints(Template)` so I could be sure that the whole process of converting `SamRecord`s to `AlignedSegment`s through to detection of breakpoints was working, and fixed up a few things I found along the way.  I'm not much more confident it's doing the right thing.
4. I would really like the tool to be able to make use of unpaired data and PE data where one end is either unmapped or has poor mapping quality.  E.g. if you have a large insertion next to a rearrangement causing say R2 to be unmapped, it would be good to be able to call the rearrangement from R1.  To this end I've pulled all read filtering up out of `AlignedSegment` and into `SvPileup.filterTemplate()` which checks to see which primary reads are acceptable and then filters those and the corresponding supplementary reads appropriately.  And added a bunch of tests for this.