### PR TITLE
SvPileup better identifies reads with SV evidence

### DIFF
--- a/docs/tools/SvPileup.md
+++ b/docs/tools/SvPileup.md
@@ -19,7 +19,7 @@ Two output files will be created:
 2. `<output-prefix>.bam`: a SAM/BAM file containing reads that contain SV breakpoint evidence annotated with SAM
   tag.
 
-The `be` SAM tag contains a comma-delimited list of breakpoints to which a given read belongs.  Each element is
+The `be` SAM tag contains a comma-delimited list of breakends to which a given read belongs.  Each element is
 a semi-colon delimited, with four fields:
 
 1. The unique breakpoint identifier (same identifier found in the tab-delimited output).

--- a/docs/tools/SvPileup.md
+++ b/docs/tools/SvPileup.md
@@ -19,7 +19,7 @@ Two output files will be created:
 2. `<output-prefix>.bam`: a SAM/BAM file containing reads that contain SV breakpoint evidence annotated with SAM
   tag.
 
-The `be` SAM tag contains a comma-delimited list of breakends to which a given read belongs.  Each element is
+The `be` SAM tag contains a comma-delimited list of breakpoints to which a given read belongs.  Each element is
 a semi-colon delimited, with four fields:
 
 1. The unique breakpoint identifier (same identifier found in the tab-delimited output).

--- a/docs/tools/SvPileup.md
+++ b/docs/tools/SvPileup.md
@@ -20,14 +20,16 @@ Two output files will be created:
   tag.
 
 The `be` SAM tag contains a comma-delimited list of breakpoints to which a given read belongs.  Each element is
-a semi-colon delimited, with three fields:
+a semi-colon delimited, with four fields:
 
 1. The unique breakpoint identifier (same identifier found in the tab-delimited output).
-2. Either "from" or "into", such that when traversing the breakpoint would read through "from" and then into
+2. Either "left" or "right, corresponding to if the read shows evidence of the genomic left or right side of the
+   breakpoint as found in the breakpoint file (i.e. `left_pos` or `right_pos`).
+3. Either "from" or "into", such that when traversing the breakpoint would read through "from" and then into
    "into" in the sequencing order of the read pair.  For a split-read alignment, the "from" contains the aligned
    portion of the read that comes from earlier in the read in sequencing order.  For an alignment of a read-pair
    spanning the breakpoint, then "from" should be read-one of the pair and "into" should be read-two of the pair.
-3. The type of breakpoint evidence: either "split_read" for observations of an aligned segment of a single read
+4. The type of breakpoint evidence: either "split_read" for observations of an aligned segment of a single read
    with split alignments, or "read_pair" for observations _between_ reads in a read pair.
 
 ## Algorithm Overview

--- a/docs/tools/SvPileup.md
+++ b/docs/tools/SvPileup.md
@@ -9,12 +9,45 @@ title: SvPileup
 
 Collates a pileup of putative structural variant supporting reads.
 
+## Outputs
+
 Two output files will be created:
 
-1. `<output-prefix>.txt`: a tab-delimited file describing SV pileups, one line per breakpiont event.
+1. `<output-prefix>.txt`: a tab-delimited file describing SV pileups, one line per breakpoint event.  The returned
+   breakpoint will be canonicalized such that the "left" side of the breakpoint will have the lower (or equal to)
+   position on the genome vs. the "right"s side.
 2. `<output-prefix>.bam`: a SAM/BAM file containing reads that contain SV breakpoint evidence annotated with SAM
-  tags.  The `ev` SAM tag lists the type of evidence found, while the `be` list the unique breakpoint identifier
-  output in (1) above.
+  tag.
+
+The `be` SAM tag contains a comma-delimited list of breakpoints to which a given read belongs.  Each element is
+a semi-colon delimited, with three fields:
+
+1. The unique breakpoint identifier (same identifier found in the tab-delimited output).
+2. Either "from" or "into", such that when traversing the breakpoint would read through "from" and then into
+   "into" in the sequencing order of the read pair.  For a split-read alignment, the "from" contains the aligned
+   portion of the read that comes from earlier in the read in sequencing order.  For an alignment of a read-pair
+   spanning the breakpoint, then "from" should be read-one of the pair and "into" should be read-two of the pair.
+3. The type of breakpoint evidence: either "split_read" for observations of an aligned segment of a single read
+   with split alignments, or "read_pair" for observations _between_ reads in a read pair.
+
+## Algorithm Overview
+
+Putative breakpoints are identified by examining the alignments for each template. The alignments are transformed
+into aligned segments in the order they were sequenced.  Each aligned segment represents the full genomic span of
+the mapped bases.  This is performed first for the primary alignments.  Next, supplementary alignments are added
+only if they map read bases that have not been previously covered by other alignments (see
+`--min-unique-bases-to-add`).  This is iteratively performed until supplementary alignments have been exhausted.
+
+Next, aligned segments that have overlapping genomic mapped bases are merged into a single aligned
+segment.  In this case, the two or more read mappings merged are associated with either the left side or right
+side of that aligned segment, controlled by examining how close to the end of the new aligned segment the given
+read mapping occurs (see `--slop` option).  This used to identify which reads traverse "from" and "into" the
+breakpoint as described above.
+
+Finally, pairs of adjacent aligned segments are examined for evidence of a breakpoint, such that genomic distance
+between them beyond either `--max-read-pair-inner-distance` for aligned segments from different read pairs, or
+`--max-aligned-segment-inner-distance` for aligned segments from the same read in a pair (i.e. split-read mapping).
+Split read evidence will be returned in favor of across-read-pair evidence when both are present.
 
 ## Arguments
 
@@ -27,4 +60,5 @@ Two output files will be created:
 |min-primary-mapping-quality|q|Int|The minimum mapping quality for primary alignments|Optional|1|30|
 |min-supplementary-mapping-quality|Q|Int|The minimum mapping quality for supplementary alignments|Optional|1|18|
 |min-unique-bases-to-add|b|Int|The minimum # of uncovered query bases needed to add a supplemental alignment|Optional|1|20|
+|slop|s|Int|The number of bases of slop to allow when determining which records to track for the left or right side of an aligned segment when merging segments.|Optional|1|5|
 

--- a/docs/tools/SvPileup.md
+++ b/docs/tools/SvPileup.md
@@ -32,6 +32,27 @@ a semi-colon delimited, with four fields:
 4. The type of breakpoint evidence: either "split_read" for observations of an aligned segment of a single read
    with split alignments, or "read_pair" for observations _between_ reads in a read pair.
 
+## Example output
+
+The following shows two breakpoints:
+
+```
+id left_contig left_pos left_strand right_contig right_pos right_strand split_reads read_pairs total
+ 1        chr1      100           +         chr2       200            -           1          0     1
+ 2        chr2      150           -         chr3       500            +           1          0     1
+```
+
+Consider a single fragment read that maps across both the above two breakpoints, so has three split-read
+alignments.  The first alignment maps on the left side of breakpoint #1, the second alignment maps to both the
+right side of breakpoint #1 and the left-side of breakpoint #2, and the third alignment maps to the right side of
+breakpoint #2. The SAM records would be as follows:
+
+```
+r1    0 chr1  50 60   50M100S ... be:Z:1;left;from;split_read
+r1 2064 chr2 150 60 50S50M50S ... be:Z:1;right;into;split_read,2;left;from;split_read
+r1 2048 chr3 500 60   100S50M ... be:Z:2;right;into;split_read
+```
+
 ## Algorithm Overview
 
 Putative breakpoints are identified by examining the alignments for each template. The alignments are transformed

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -4,7 +4,8 @@ title: fgsv tools
 
 # fgsv tools
 
-The following tools are available in fgsv version 20220324-18de981.
+The following tools are available in fgsv version 20220323-9e90d4c.
+
 ## All tools
 
 All tools.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -4,8 +4,7 @@ title: fgsv tools
 
 # fgsv tools
 
-The following tools are available in fgsv version 20220323-9e90d4c.
-
+The following tools are available in fgsv version 20220325-92d5251.
 ## All tools
 
 All tools.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -4,7 +4,7 @@ title: fgsv tools
 
 # fgsv tools
 
-The following tools are available in fgsv version 20220328-75cbad5.
+The following tools are available in fgsv version 20220404-21ff530.
 ## All tools
 
 All tools.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -4,7 +4,7 @@ title: fgsv tools
 
 # fgsv tools
 
-The following tools are available in fgsv version 20220404-21ff530.
+The following tools are available in fgsv version 20220404-72483d3.
 ## All tools
 
 All tools.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -4,7 +4,7 @@ title: fgsv tools
 
 # fgsv tools
 
-The following tools are available in fgsv version 20220325-92d5251.
+The following tools are available in fgsv version 20220328-75cbad5.
 ## All tools
 
 All tools.

--- a/src/main/scala/com/fulcrumgenomics/sv/AlignedSegment.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/AlignedSegment.scala
@@ -32,8 +32,8 @@ case class AlignedSegment(origin: SegmentOrigin,
                           positiveStrand: Boolean,
                           private val cigar: Cigar,
                           range: GenomicRange,
-                          left: Seq[SamRecord] = IndexedSeq.empty,
-                          right: Seq[SamRecord] = IndexedSeq.empty) {
+                          left: Seq[SamRecord] = AlignedSegment.NoReads,
+                          right: Seq[SamRecord] = AlignedSegment.NoReads) {
   require(0 < readStart)
   require(readStart <= readEnd)
 
@@ -81,6 +81,8 @@ case class AlignedSegment(origin: SegmentOrigin,
 object AlignedSegment extends LazyLogging {
   private val NoSegments: IndexedSeq[AlignedSegment] = IndexedSeq.empty
 
+  private val NoReads: IndexedSeq[SamRecord] = IndexedSeq.empty[SamRecord]
+
   /** Builds an alignment segment from a [[SamRecord]]
    *
    * @param rec the mapped record
@@ -103,6 +105,8 @@ object AlignedSegment extends LazyLogging {
       else                    (trailingClipping + 1, trailingClipping + middle)
     }
 
+    val recs = IndexedSeq(rec)
+
     AlignedSegment(
       origin         = SegmentOrigin(rec),
       readStart      = start,
@@ -110,8 +114,8 @@ object AlignedSegment extends LazyLogging {
       positiveStrand = rec.positiveStrand,
       cigar          = rec.cigar,
       range          = range,
-      left           = IndexedSeq(rec),
-      right          = IndexedSeq(rec)
+      left           = recs,
+      right          = recs
     )
   }
 

--- a/src/main/scala/com/fulcrumgenomics/sv/Breakpoint.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/Breakpoint.scala
@@ -11,10 +11,12 @@ object Breakpoint {
    * segments could be from different reads in a mate pair, this cannot be validated/required()
    * in this method, but violating this assumption will lead to invalid breakpoints.
    *
-   * The returned breakpoint will be canonicalized such that the `left` side of the breakpoint will have the
-   * lower (or equal to) position on the genome vs. the `right` side.
+   * @param into the segment earlier in sequencing order
+   * @param from the segment later in sequencing order
+   * @param canonicalize canonicalize the breakpoint such that the `left` side of the breakpoint will have the lower
+   *                     (or equal to) position on the genome vs. the `right` side.
    */
-  def apply(from: AlignedSegment, into: AlignedSegment): Breakpoint = {
+  def apply(from: AlignedSegment, into: AlignedSegment, canonicalize: Boolean = true): Breakpoint = {
     val bp = Breakpoint(
       leftRefIndex  = from.range.refIndex,
       leftPos       = if (from.positiveStrand) from.range.end else from.range.start,
@@ -24,7 +26,7 @@ object Breakpoint {
       rightPositive = into.positiveStrand
     )
 
-    if (bp.isCanonical) bp else bp.reversed
+    if (!canonicalize || bp.isCanonical) bp else bp.reversed
   }
 
   /**

--- a/src/main/scala/com/fulcrumgenomics/sv/Breakpoint.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/Breakpoint.scala
@@ -90,7 +90,7 @@ case class Breakpoint(leftRefIndex: Int,
     rightPositive = !leftPositive
   )
 
-  /** Returns true if the representation of the breakend is canonical, with the left hand side of the break
+  /** Returns true if the representation of the breakpoint is canonical, with the left hand side of the break
    * earlier on the genome than the right hand side. */
   def isCanonical: Boolean = (leftRefIndex < rightRefIndex) ||
     (leftRefIndex == rightRefIndex && leftPos < rightPos) ||

--- a/src/main/scala/com/fulcrumgenomics/sv/BreakpointEvidence.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/BreakpointEvidence.scala
@@ -19,11 +19,14 @@ object BreakpointEvidence {
   def apply(from: AlignedSegment,
             into: AlignedSegment,
             evidence: EvidenceType): BreakpointEvidence = {
+    val breakpoint = Breakpoint(from, into, canonicalize=false)
+    val isCanonical = breakpoint.isCanonical
     new BreakpointEvidence(
-      breakpoint = Breakpoint(from, into),
+      breakpoint = if (isCanonical) breakpoint else breakpoint.reversed,
       evidence   = evidence,
       from       = (if (from.positiveStrand) from.right else from.left).toSet,
-      into       = (if (into.positiveStrand) into.left else into.right).toSet
+      into       = (if (into.positiveStrand) into.left else into.right).toSet,
+      fromIsLeft = isCanonical,
     )
   }
 }
@@ -35,8 +38,10 @@ object BreakpointEvidence {
  * @param evidence the type of evidence for this breakpoint
  * @param from the [[SamRecord]](s) that provided evidence of this break point going "from" the breakpoint
  * @param into the [[SamRecord]](s) that provided evidence of this break point going "into" the breakpoint
+ * @param fromIsLeft if the records in `from` correspond to the left side of the breakpoint, otherwise the right
  */
 case class BreakpointEvidence(breakpoint: Breakpoint,
                               evidence: EvidenceType,
                               from: Set[SamRecord] = Set.empty,
-                              into: Set[SamRecord] = Set.empty)
+                              into: Set[SamRecord] = Set.empty,
+                              fromIsLeft: Boolean = true)

--- a/src/main/scala/com/fulcrumgenomics/sv/BreakpointEvidence.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/BreakpointEvidence.scala
@@ -19,7 +19,12 @@ object BreakpointEvidence {
   def apply(from: AlignedSegment,
             into: AlignedSegment,
             evidence: EvidenceType): BreakpointEvidence = {
-    new BreakpointEvidence(breakpoint=Breakpoint(from, into), evidence=evidence, recs=(from.recs++into.recs).toSet)
+    new BreakpointEvidence(
+      breakpoint = Breakpoint(from, into),
+      evidence   = evidence,
+      from       = (if (from.positiveStrand) from.right else from.left).toSet,
+      into       = (if (into.positiveStrand) into.left else into.right).toSet
+    )
   }
 }
 
@@ -28,8 +33,10 @@ object BreakpointEvidence {
  *
  * @param breakpoint the breakpoint for which we have evidence
  * @param evidence the type of evidence for this breakpoint
- * @param recs the [[SamRecord]](s) that provided evidence of this break point
+ * @param from the [[SamRecord]](s) that provided evidence of this break point going "from" the breakpoint
+ * @param into the [[SamRecord]](s) that provided evidence of this break point going "into" the breakpoint
  */
 case class BreakpointEvidence(breakpoint: Breakpoint,
                               evidence: EvidenceType,
-                              recs: Set[SamRecord] = Set.empty)
+                              from: Set[SamRecord] = Set.empty,
+                              into: Set[SamRecord] = Set.empty)

--- a/src/main/scala/com/fulcrumgenomics/sv/BreakpointEvidence.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/BreakpointEvidence.scala
@@ -32,13 +32,4 @@ object BreakpointEvidence {
  */
 case class BreakpointEvidence(breakpoint: Breakpoint,
                               evidence: EvidenceType,
-                              recs: Set[SamRecord] = Set.empty) extends Ordered[BreakpointEvidence] {
-
-  /** Defines an ordering over breakpoints, first by genomic coordinates of the left then right end, then evidence type.
-   *  Ignores the origin of the breakpoint and evidence */
-  def compare(that: BreakpointEvidence): Int = {
-    var result              = this.breakpoint.compare(that.breakpoint)
-    if (result == 0) result = this.evidence.compare(that.evidence)
-    result
-  }
-}
+                              recs: Set[SamRecord] = Set.empty)

--- a/src/main/scala/com/fulcrumgenomics/sv/BreakpointEvidence.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/BreakpointEvidence.scala
@@ -1,5 +1,7 @@
 package com.fulcrumgenomics.sv
 
+import com.fulcrumgenomics.bam.api.SamRecord
+
 object BreakpointEvidence {
   /**
    * Builds a breakpoint evidence from two aligned segments and an evidence type.
@@ -17,7 +19,7 @@ object BreakpointEvidence {
   def apply(from: AlignedSegment,
             into: AlignedSegment,
             evidence: EvidenceType): BreakpointEvidence = {
-    new BreakpointEvidence(breakpoint = Breakpoint(from, into), evidence = evidence)
+    new BreakpointEvidence(breakpoint=Breakpoint(from, into), evidence=evidence, recs=(from.recs++into.recs).toSet)
   }
 }
 
@@ -26,10 +28,14 @@ object BreakpointEvidence {
  *
  * @param breakpoint the breakpoint for which we have evidence
  * @param evidence the type of evidence for this breakpoint
+ * @param recs the [[SamRecord]](s) that provided evidence of this break point
  */
-case class BreakpointEvidence(breakpoint: Breakpoint, evidence: EvidenceType) extends Ordered[BreakpointEvidence] {
+case class BreakpointEvidence(breakpoint: Breakpoint,
+                              evidence: EvidenceType,
+                              recs: Set[SamRecord] = Set.empty) extends Ordered[BreakpointEvidence] {
 
-  /** Defines an ordering over breakpoints, first by genomic coordinates of the left then right end, then evidence type. */
+  /** Defines an ordering over breakpoints, first by genomic coordinates of the left then right end, then evidence type.
+   *  Ignores the origin of the breakpoint and evidence */
   def compare(that: BreakpointEvidence): Int = {
     var result              = this.breakpoint.compare(that.breakpoint)
     if (result == 0) result = this.evidence.compare(that.evidence)

--- a/src/main/scala/com/fulcrumgenomics/sv/tools/SvPileup.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/tools/SvPileup.scala
@@ -44,6 +44,27 @@ import scala.collection.mutable
     |4. The type of breakpoint evidence: either "split_read" for observations of an aligned segment of a single read
     |   with split alignments, or "read_pair" for observations _between_ reads in a read pair.
     |
+    |## Example output
+    |
+    |The following shows two breakpoints:
+    |
+    |```
+    |id left_contig left_pos left_strand right_contig right_pos right_strand split_reads read_pairs total
+    | 1        chr1      100           +         chr2       200            -           1          0     1
+    | 2        chr2      150           -         chr3       500            +           1          0     1
+    |```
+    |
+    |Consider a single fragment read that maps across both the above two breakpoints, so has three split-read
+    |alignments.  The first alignment maps on the left side of breakpoint #1, the second alignment maps to both the
+    |right side of breakpoint #1 and the left-side of breakpoint #2, and the third alignment maps to the right side of
+    |breakpoint #2. The SAM records would be as follows:
+    |
+    |```
+    |r1    0 chr1  50 60   50M100S ... be:Z:1;left;from;split_read
+    |r1 2064 chr2 150 60 50S50M50S ... be:Z:1;right;into;split_read,2;left;from;split_read
+    |r1 2048 chr3 500 60   100S50M ... be:Z:2;right;into;split_read
+    |```
+    |
     |## Algorithm Overview
     |
     |Putative breakpoints are identified by examining the alignments for each template. The alignments are transformed

--- a/src/main/scala/com/fulcrumgenomics/sv/tools/SvPileup.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/tools/SvPileup.scala
@@ -58,7 +58,7 @@ import scala.collection.mutable
     |
     |Finally, pairs of adjacent aligned segments are examined for evidence of a breakpoint, such that genomic distance
     |between them beyond either `--max-read-pair-inner-distance` for aligned segments from different read pairs, or
-    |--max-aligned-segment-inner-distance` for aligned segments from the same read in a pair (i.e. split-read mapping).
+    |`--max-aligned-segment-inner-distance` for aligned segments from the same read in a pair (i.e. split-read mapping).
     |Split read evidence will be returned in favor of across-read-pair evidence when both are present.
   """)
 class SvPileup

--- a/src/test/scala/com/fulcrumgenomics/sv/AlignedSegmentTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/sv/AlignedSegmentTest.scala
@@ -18,58 +18,63 @@ class AlignedSegmentTest extends UnitSpec {
   "AlignedSegment" should "be built from a SamRecord" in {
     implicit val builder: SamBuilder = new SamBuilder()
 
+    def test(rec: SamRecord, expected: AlignedSegment): Unit = {
+      val actual = AlignedSegment(rec)
+      actual shouldBe expected.copy(recs=IndexedSeq(rec))
+    }
+
     // All bases mapped
-    AlignedSegment(readEnd(start=1, cigar="100M")) shouldBe AlignedSegment(
+    test(readEnd(start=1, cigar="100M"), AlignedSegment(
       origin=ReadOne,
       readStart=1, readEnd=100, positiveStrand=true, cigar=Cigar("100M"),
       range=GenomicRange(refIndex=0, start=1, end=100)
-    )
-    AlignedSegment(readEnd(start=1, cigar="100M", firstOfPair=false)) shouldBe AlignedSegment(
+    ))
+    test(readEnd(start=1, cigar="100M", firstOfPair=false), AlignedSegment(
       origin=ReadTwo,
       readStart=1, readEnd=100, positiveStrand=true, cigar=Cigar("100M"),
       range=GenomicRange(refIndex=0, start=1, end=100),
-    )
-    AlignedSegment(readEnd(start=1, cigar="100M", strand=SamBuilder.Minus)) shouldBe AlignedSegment(
+    ))
+    test(readEnd(start=1, cigar="100M", strand=SamBuilder.Minus), AlignedSegment(
       origin=ReadOne,
       readStart=1, readEnd=100, positiveStrand=false, cigar=Cigar("100M"),
       range=GenomicRange(refIndex=0, start=1, end=100)
-    )
+    ))
 
     // Leading soft-clipping
-    AlignedSegment(readEnd(start=11, cigar="10S90M")) shouldBe AlignedSegment(
+    test(readEnd(start=11, cigar="10S90M"), AlignedSegment(
       origin=ReadOne,
       readStart=11, readEnd=100, positiveStrand=true, cigar=Cigar("10S90M"),
       range=GenomicRange(refIndex=0, start=11, end=100)
-    )
-    AlignedSegment(readEnd(start=11, cigar="10S90M", strand=SamBuilder.Minus)) shouldBe AlignedSegment(
+    ))
+    test(readEnd(start=11, cigar="10S90M", strand=SamBuilder.Minus), AlignedSegment(
       origin=ReadOne,
       readStart=1, readEnd=90, positiveStrand=false, cigar=Cigar("10S90M"),
       range=GenomicRange(refIndex=0, start=11, end=100)
-    )
+    ))
 
     // trailing soft-clipping
-    AlignedSegment(readEnd(start=1, cigar="90M10S")) shouldBe AlignedSegment(
+    test(readEnd(start=1, cigar="90M10S"), AlignedSegment(
       origin=ReadOne,
       readStart=1, readEnd=90, positiveStrand=true, cigar=Cigar("90M10S"),
       range=GenomicRange(refIndex=0, start=1, end=90)
-    )
-    AlignedSegment(readEnd(start=1, cigar="90M10S", strand=SamBuilder.Minus)) shouldBe AlignedSegment(
+    ))
+    test(readEnd(start=1, cigar="90M10S", strand=SamBuilder.Minus), AlignedSegment(
       origin=ReadOne,
       readStart=11, readEnd=100, positiveStrand=false, cigar=Cigar("90M10S"),
       range=GenomicRange(refIndex=0, start=1, end=90)
-    )
+    ))
 
     // lots of clipping
-    AlignedSegment(readEnd(start=10, cigar="1H4S90M6S2H")) shouldBe AlignedSegment(
+    test(readEnd(start=10, cigar="1H4S90M6S2H"), AlignedSegment(
       origin=ReadOne,
       readStart=6, readEnd=95, positiveStrand=true, cigar=Cigar("1H4S90M6S2H"),
       range=GenomicRange(refIndex=0, start=10, end=99)
-    )
-    AlignedSegment(readEnd(start=10, cigar="1H4S90M6S2H", strand=SamBuilder.Minus)) shouldBe AlignedSegment(
+    ))
+    test(readEnd(start=10, cigar="1H4S90M6S2H", strand=SamBuilder.Minus), AlignedSegment(
       origin=ReadOne,
       readStart=9, readEnd=98, positiveStrand=false, cigar=Cigar("1H4S90M6S2H"),
       range=GenomicRange(refIndex=0, start=10, end=99)
-    )
+    ))
   }
 
   "AlignedSegment.segmentsFrom" should "create segments from a primary and one supplementals" in {

--- a/src/test/scala/com/fulcrumgenomics/sv/AlignedSegmentTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/sv/AlignedSegmentTest.scala
@@ -20,7 +20,7 @@ class AlignedSegmentTest extends UnitSpec {
 
     def test(rec: SamRecord, expected: AlignedSegment): Unit = {
       val actual = AlignedSegment(rec)
-      actual shouldBe expected.copy(recs=IndexedSeq(rec))
+      actual shouldBe expected.copy(left=IndexedSeq(rec), right=IndexedSeq(rec))
     }
 
     // All bases mapped
@@ -121,10 +121,10 @@ class AlignedSegmentTest extends UnitSpec {
   }
 
   "AlignedSegment.mergeReadSegments" should " merge read segments" in {
-    val r1 = GenomicRange(refIndex=0, start=1, end=50) // overlaps nothing
+    val r1 = GenomicRange(refIndex=0, start=1, end=50)    // overlaps nothing
     val r2 = GenomicRange(refIndex=0, start=100, end=150) // overlaps r1
     val r3 = GenomicRange(refIndex=0, start=125, end=175) // overlaps r2
-    val r4 = GenomicRange(refIndex=1, start=1, end=1000) // overlaps nothing
+    val r4 = GenomicRange(refIndex=1, start=1, end=1000)  // overlaps nothing
 
     // No overlaps with one segment on R1 and two on R2
     {

--- a/src/test/scala/com/fulcrumgenomics/sv/UnitSpec.scala
+++ b/src/test/scala/com/fulcrumgenomics/sv/UnitSpec.scala
@@ -1,6 +1,24 @@
 package com.fulcrumgenomics.sv
 
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import com.fulcrumgenomics.FgBioDef.PathToBam
+import com.fulcrumgenomics.bam.api.{SamRecord, SamSource}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.{Matchers, OptionValues}
+
+import java.nio.file.{Files, Path}
 
 /** Base class for unit tests. */
-class UnitSpec extends FlatSpec with Matchers with OptionValues {}
+trait UnitSpec extends AnyFlatSpec with Matchers with OptionValues {
+  // Turn down HTSJDK logging
+  htsjdk.samtools.util.Log.setGlobalLogLevel(htsjdk.samtools.util.Log.LogLevel.WARNING)
+
+  /** Creates a new temp file for use in testing that will be deleted when the VM exits. */
+  protected def makeTempFile(prefix: String, suffix: String) : Path = {
+    val path = Files.createTempFile(prefix, suffix)
+    path.toFile.deleteOnExit()
+    path
+  }
+
+  /** Reads all the records from a SAM or BAM file into an indexed seq. */
+  protected def readBamRecs(bam: PathToBam): IndexedSeq[SamRecord] = SamSource(bam).toIndexedSeq
+}

--- a/src/test/scala/com/fulcrumgenomics/sv/tools/SvPileupTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/sv/tools/SvPileupTest.scala
@@ -449,10 +449,10 @@ class SvPileupTest extends UnitSpec {
     val fromTag = s"0;from;${SplitRead.snakeName}"
     val intoTag = f"0;into;${SplitRead.snakeName}"
 
-//    // r1Half2 is not annotated, since it is superseded by r1Half1 -> fullR2
-//    SamPairUtil.setMateInfo(r1Half1.asSam, fullR2.asSam, true)
-//    SamPairUtil.setMateInformationOnSupplementalAlignment(r1Half2.asSam, fullR2.asSam, true)
-//    test(Seq(r1Half2, r1Half1, fullR2), Seq(fromTag, "", intoTag))
+    // r1Half2 is not annotated, since it is superseded by r1Half1 -> fullR2
+    SamPairUtil.setMateInfo(r1Half1.asSam, fullR2.asSam, true)
+    SamPairUtil.setMateInformationOnSupplementalAlignment(r1Half2.asSam, fullR2.asSam, true)
+    test(Seq(r1Half2, r1Half1, fullR2), Seq(fromTag, "", intoTag))
 
     // fullR1 does not contain the breakpoint, while r2Half2 -> r2Half1 does (NB: the from->into are on the reverse strand)
     SamPairUtil.setMateInfo(fullR1.asSam, r2Half1.asSam, true)

--- a/src/test/scala/com/fulcrumgenomics/sv/tools/SvPileupTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/sv/tools/SvPileupTest.scala
@@ -446,23 +446,25 @@ class SvPileupTest extends UnitSpec {
       }
     }
 
-    val fromTag = s"0;from;${SplitRead.snakeName}"
-    val intoTag = f"0;into;${SplitRead.snakeName}"
+    val leftFromTag  = s"0;left;from;${SplitRead.snakeName}"
+    val rightFromTag = s"0;right;from;${SplitRead.snakeName}"
+    val leftIntoTag  = f"0;left;into;${SplitRead.snakeName}"
+    val rightIntoTag = f"0;right;into;${SplitRead.snakeName}"
 
     // r1Half2 is not annotated, since it is superseded by r1Half1 -> fullR2
     SamPairUtil.setMateInfo(r1Half1.asSam, fullR2.asSam, true)
     SamPairUtil.setMateInformationOnSupplementalAlignment(r1Half2.asSam, fullR2.asSam, true)
-    test(Seq(r1Half2, r1Half1, fullR2), Seq(fromTag, "", intoTag))
+    test(Seq(r1Half2, r1Half1, fullR2), Seq(leftFromTag, "", rightIntoTag))
 
     // fullR1 does not contain the breakpoint, while r2Half2 -> r2Half1 does (NB: the from->into are on the reverse strand)
     SamPairUtil.setMateInfo(fullR1.asSam, r2Half1.asSam, true)
     SamPairUtil.setMateInformationOnSupplementalAlignment(r2Half2.asSam, fullR1.asSam, true)
-    test(Seq(fullR1, r2Half1, r2Half2), Seq("", intoTag, fromTag))
+    test(Seq(fullR1, r2Half1, r2Half2), Seq("", rightIntoTag, leftFromTag))
 
     // all the reads are annotated!
     SamPairUtil.setMateInfo(r1Half1.asSam, r2Half1.asSam, true)
     SamPairUtil.setMateInformationOnSupplementalAlignment(r2Half2.asSam, r1Half1.asSam, true)
     SamPairUtil.setMateInformationOnSupplementalAlignment(r1Half2.asSam, r2Half1.asSam, true)
-    test(Seq(r1Half1, r1Half2, r2Half1, r2Half2), Seq(fromTag, intoTag, intoTag, fromTag))
+    test(Seq(r1Half1, r1Half2, r2Half1, r2Half2), Seq(leftFromTag, rightIntoTag, rightIntoTag, leftFromTag))
   }
 }


### PR DESCRIPTION
Previously, all reads in a template would be annotated with the SV
evidence if any of the reads in the template exhibited SV evidence.
Now, only those reads that show evidence of a specific breakpoint
are annoated.