### PR TITLE
Fix Stack overflow for large clusters

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -4,7 +4,7 @@ title: fgsv tools
 
 # fgsv tools
 
-The following tools are available in fgsv version 20220526-658406c.
+The following tools are available in fgsv version 20220914-a50f9f9.
 ## All tools
 
 All tools.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -4,8 +4,7 @@ title: fgsv tools
 
 # fgsv tools
 
-The following tools are available in fgsv version 20220914-a50f9f9.
-
+The following tools are available in fgsv version 20220914-806d6a2.
 ## All tools
 
 All tools.

--- a/src/main/scala/com/fulcrumgenomics/sv/tools/AggregateSvPileup.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/tools/AggregateSvPileup.scala
@@ -182,7 +182,7 @@ object AggregateSvPileup {
    *
    * @param pileup The pileup representative of the cluster that will be returned
    * @param pileupToNeighbors Map of pileup to its set of neighbors
-   * @parma neighborsToIgnore Set of pileups to ignore, as they are being considered in parent calls to this method
+   * @param neighborsToIgnore Set of pileups to ignore, as they are being considered in parent calls to this method
    * @return (1) The complete cluster for the given pileup; (2) Reduced version of `pileupToNeighbors` with all pileups
    *         in the returned cluster having been removed from both keys and values.
    */

--- a/src/main/scala/com/fulcrumgenomics/sv/tools/AggregateSvPileup.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/tools/AggregateSvPileup.scala
@@ -168,18 +168,20 @@ object AggregateSvPileup {
       if (!visited.contains(rootPileup)) {
         val remaining = scala.collection.mutable.Queue[BreakpointPileup]()
         val component = Set.newBuilder[BreakpointPileup]
-        remaining += rootPileup
+        remaining.enqueue(rootPileup)
         while (remaining.nonEmpty) {
           // get the next pileup to examine
           val curPileup = remaining.dequeue()
-          if (!visited.contains(curPileup)) {
-            // add it to this component
-            component += curPileup
-            // add all unvisited neighbors
-            remaining ++= pileupToNeighbors(curPileup).filterNot(visited.contains)
-            // marks this pileup as visited
-            visited.add(curPileup)
-          }
+          // add it to this component
+          component += curPileup
+          // find all unvisited neighbors
+          val unvisited = pileupToNeighbors(curPileup).filterNot(visited.contains)
+          // add the unvisited neighbors to the queue
+          remaining ++= unvisited
+          // mark the unvisited neighbors as being visited so we don't enqueue them later
+          unvisited.foreach(visited.add)
+          // mark this pileup as visited
+          visited.add(curPileup)
         }
         components += component.result().toIndexedSeq
       }

--- a/src/test/scala/com/fulcrumgenomics/sv/tools/AggregateSvPileupTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/sv/tools/AggregateSvPileupTest.scala
@@ -231,22 +231,6 @@ class AggregateSvPileupTest extends UnitSpec {
     )
   }
 
-  "AggregateSvPileup.extractClusterFor" should "return correct cluster of size 1" in {
-    AggregateSvPileup.extractClusterFor(pileup_id6_1_300_plus_3_401_plus, pileup_to_neighbors_1_plus_plus) should be (
-      IndexedSeq(pileup_id6_1_300_plus_3_401_plus), pileup_to_neighbors_1_plus_plus.removed(pileup_id6_1_300_plus_3_401_plus)
-    )
-  }
-
-  it should "return correct cluster of size > 1" in {
-    val pileups = IndexedSeq(pileup_id112_1_100_plus_3_200_plus, pileup_id456_1_200_plus_3_100_plus, pileup_id5_1_300_plus_3_200_plus)
-    pileups.foreach {pileup =>
-      AggregateSvPileup.extractClusterFor(pileup, pileup_to_neighbors_1_plus_plus) match {
-        case (cluster, _) =>
-          cluster should contain theSameElementsAs pileups
-      }
-    }
-  }
-
   "AggregateSvPileup" should "return an empty seq for empty input" in {
     runEndToEnd(IndexedSeq()) shouldEqual IndexedSeq()
   }
@@ -365,7 +349,6 @@ class AggregateSvPileupTest extends UnitSpec {
 
     val aggregatedPileups = runEndToEnd(pileups)
     aggregatedPileups should contain theSameElementsAs IndexedSeq(expAgg1, expAgg2, expAgg3, expAgg4)
-
   }
 
   it should "aggregate multiple pileups with bam and target files" in {


### PR DESCRIPTION
I'd rather have `extractClusterFor` be tail recursive or in a loop, but I couldn't figure out how to do that easily, so this will do.  