### PR TITLE
Add option BED file to SvPileup

### DIFF
--- a/docs/04_Metrics.md
+++ b/docs/04_Metrics.md
@@ -66,8 +66,8 @@ the only information comes from read-pairs and the breakpoint information should
 |split_reads|Int|The number of templates/inserts with split-read alignments that identified this breakpoint.|
 |read_pairs|Int|The number of templates/inserts with read-pair alignments (and without split-read alignments)                      that identified this breakpoint.|
 |total|Int|The total number of templates/inserts that identified this breakpoint|
-|left_target|Option[String]|The comma-delimited list of target names overlapping the left breakpoint|
-|right_target|Option[String]|The comma-delimited list of target names overlapping the right breakpoint|
+|left_targets|Option[String]|The comma-delimited list of target names overlapping the left breakpoint|
+|right_targets|Option[String]|The comma-delimited list of target names overlapping the right breakpoint|
 
 
 ### MergedPileup

--- a/docs/04_Metrics.md
+++ b/docs/04_Metrics.md
@@ -66,6 +66,8 @@ the only information comes from read-pairs and the breakpoint information should
 |split_reads|Int|The number of templates/inserts with split-read alignments that identified this breakpoint.|
 |read_pairs|Int|The number of templates/inserts with read-pair alignments (and without split-read alignments)                      that identified this breakpoint.|
 |total|Int|The total number of templates/inserts that identified this breakpoint|
+|left_target|Option[String]|The comma-delimited list of target names overlapping the left breakpoint|
+|right_target|Option[String]|The comma-delimited list of target names overlapping the right breakpoint|
 
 
 ### MergedPileup

--- a/docs/tools/SvPileup.md
+++ b/docs/tools/SvPileup.md
@@ -85,5 +85,5 @@ Split read evidence will be returned in favor of across-read-pair evidence when 
 |min-unique-bases-to-add|b|Int|The minimum # of uncovered query bases needed to add a supplemental alignment|Optional|1|20|
 |slop|s|Int|The number of bases of slop to allow when determining which records to track for the left or right side of an aligned segment when merging segments.|Optional|1|5|
 |targets-bed|t|FilePath|Optional bed file of target regions|Optional|1||
-|both-ends-overlap-targets|B|Boolean|Require both ends of a breakpoint to overlap the target regions|Optional|1|false|
+|targets-bed-requirement|T|Requirement|Requirement on if each side of the breakpoint must overlap a target.  Will always annotate each side of the breakpoint.|Optional|1|AnnotateOnly|
 

--- a/docs/tools/SvPileup.md
+++ b/docs/tools/SvPileup.md
@@ -84,4 +84,6 @@ Split read evidence will be returned in favor of across-read-pair evidence when 
 |min-supplementary-mapping-quality|Q|Int|The minimum mapping quality for supplementary alignments|Optional|1|18|
 |min-unique-bases-to-add|b|Int|The minimum # of uncovered query bases needed to add a supplemental alignment|Optional|1|20|
 |slop|s|Int|The number of bases of slop to allow when determining which records to track for the left or right side of an aligned segment when merging segments.|Optional|1|5|
+|targets-bed|t|FilePath|Optional bed file of target regions|Optional|1||
+|both-ends-overlap-targets|B|Boolean|Require both ends of a breakpoint to overlap the target regions|Optional|1|false|
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -4,7 +4,7 @@ title: fgsv tools
 
 # fgsv tools
 
-The following tools are available in fgsv version 20230515-b620341.
+The following tools are available in fgsv version 20230515-0b0c111.
 ## All tools
 
 All tools.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -4,7 +4,7 @@ title: fgsv tools
 
 # fgsv tools
 
-The following tools are available in fgsv version 20230515-0b0c111.
+The following tools are available in fgsv version 20230516-51c773a.
 ## All tools
 
 All tools.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -4,7 +4,7 @@ title: fgsv tools
 
 # fgsv tools
 
-The following tools are available in fgsv version 20220916-16957b2.
+The following tools are available in fgsv version 20230511-f661fdb.
 ## All tools
 
 All tools.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -4,7 +4,7 @@ title: fgsv tools
 
 # fgsv tools
 
-The following tools are available in fgsv version 20230511-f661fdb.
+The following tools are available in fgsv version 20230515-b620341.
 ## All tools
 
 All tools.

--- a/src/main/scala/com/fulcrumgenomics/sv/Breakpoint.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/Breakpoint.scala
@@ -1,5 +1,8 @@
 package com.fulcrumgenomics.sv
 
+import com.fulcrumgenomics.fasta.SequenceDictionary
+import htsjdk.samtools.util.Interval
+
 object Breakpoint {
   /**
    * Builds a breakpoint from two aligned segments.
@@ -97,4 +100,19 @@ case class Breakpoint(leftRefIndex: Int,
   def isCanonical: Boolean = (leftRefIndex < rightRefIndex) ||
     (leftRefIndex == rightRefIndex && leftPos < rightPos) ||
     (leftRefIndex == rightRefIndex && leftPos == rightPos && leftPositive)
+
+  /** Returns an [[Interval]] for the left side of this breakpoint */
+  def leftInterval(dict: SequenceDictionary): Interval = new Interval(
+    dict(leftRefIndex).name,
+    leftPos,
+    leftPos
+  )
+
+  /** Returns an [[Interval]] for the right side of this breakpoint */
+  def rightInterval(dict: SequenceDictionary): Interval = new Interval(
+    dict(rightRefIndex).name,
+    rightPos,
+    rightPos
+  )
+
 }

--- a/src/main/scala/com/fulcrumgenomics/sv/BreakpointPileup.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/BreakpointPileup.scala
@@ -22,6 +22,8 @@ import com.fulcrumgenomics.util.Metric
  * @param read_pairs    the number of templates/inserts with read-pair alignments (and without split-read alignments)
  *                      that identified this breakpoint.
  * @param total         the total number of templates/inserts that identified this breakpoint
+ * @param left_target   the comma-delimited list of target names overlapping the left breakpoint
+ * @param right_target  the comma-delimited list of target names overlapping the right breakpoint
  */
 case class BreakpointPileup(id: String,
                             left_contig: String,
@@ -32,12 +34,15 @@ case class BreakpointPileup(id: String,
                             right_strand: Char,
                             split_reads: Int,
                             read_pairs: Int,
-                            total: Int
+                            total: Int,
+                            left_target: Option[String] = None,
+                            right_target: Option[String] = None
                            ) extends Metric {
 
   override def toString(): String = f"$id|$left_contig:$left_pos($left_strand)/" +
     f"$right_contig:$right_pos($right_strand)|" +
-    f"$split_reads,$read_pairs,$total"
+    f"$split_reads,$read_pairs,$total" +
+    f"${left_target.getOrElse("")},${right_target.getOrElse("")}"
 
   lazy val contigOrientation: BreakpointContigOrientation = BreakpointContigOrientation(this)
 

--- a/src/main/scala/com/fulcrumgenomics/sv/BreakpointPileup.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/BreakpointPileup.scala
@@ -22,8 +22,8 @@ import com.fulcrumgenomics.util.Metric
  * @param read_pairs    the number of templates/inserts with read-pair alignments (and without split-read alignments)
  *                      that identified this breakpoint.
  * @param total         the total number of templates/inserts that identified this breakpoint
- * @param left_target   the comma-delimited list of target names overlapping the left breakpoint
- * @param right_target  the comma-delimited list of target names overlapping the right breakpoint
+ * @param left_targets  the comma-delimited list of target names overlapping the left breakpoint
+ * @param right_targets the comma-delimited list of target names overlapping the right breakpoint
  */
 case class BreakpointPileup(id: String,
                             left_contig: String,
@@ -35,14 +35,15 @@ case class BreakpointPileup(id: String,
                             split_reads: Int,
                             read_pairs: Int,
                             total: Int,
-                            left_target: Option[String] = None,
-                            right_target: Option[String] = None
+                            left_targets: Option[String] = None,
+                            right_targets: Option[String] = None
                            ) extends Metric {
 
   override def toString(): String = f"$id|$left_contig:$left_pos($left_strand)/" +
     f"$right_contig:$right_pos($right_strand)|" +
     f"$split_reads,$read_pairs,$total" +
-    f"${left_target.getOrElse("")},${right_target.getOrElse("")}"
+    f",${left_targets.map(_.replace(',', ';')).getOrElse("")}" +
+    f",${right_targets.map(_.replace(',', ';')).getOrElse("")}"
 
   lazy val contigOrientation: BreakpointContigOrientation = BreakpointContigOrientation(this)
 

--- a/src/main/scala/com/fulcrumgenomics/sv/FgSvDef.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/FgSvDef.scala
@@ -1,0 +1,16 @@
+package com.fulcrumgenomics.sv
+
+import com.fulcrumgenomics.FgBioDef.FilePath
+import htsjdk.samtools.util.OverlapDetector
+import htsjdk.tribble.AbstractFeatureReader
+import htsjdk.tribble.bed.{BEDCodec, BEDFeature}
+
+object FgSvDef {
+  /** Builds an [[OverlapDetector]] frpom a BED file */
+  def overlapDetectorFrom(bed: FilePath): OverlapDetector[BEDFeature] = {
+    val bedReader = AbstractFeatureReader.getFeatureReader (bed.toAbsolutePath.toString, new BEDCodec (), false)
+    val bedFeatures: java.util.List[BEDFeature] = bedReader.iterator ().toList
+    bedReader.close()
+    OverlapDetector.create (bedFeatures)
+  }
+}

--- a/src/main/scala/com/fulcrumgenomics/sv/Intervals.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/Intervals.scala
@@ -4,13 +4,12 @@ import com.fulcrumgenomics.FgBioDef.FilePath
 import htsjdk.samtools.util.OverlapDetector
 import htsjdk.tribble.AbstractFeatureReader
 import htsjdk.tribble.bed.{BEDCodec, BEDFeature}
-
-object FgSvDef {
-  /** Builds an [[OverlapDetector]] frpom a BED file */
+object Intervals {
+  /** Builds an [[OverlapDetector]] from a BED file */
   def overlapDetectorFrom(bed: FilePath): OverlapDetector[BEDFeature] = {
-    val bedReader = AbstractFeatureReader.getFeatureReader (bed.toAbsolutePath.toString, new BEDCodec (), false)
-    val bedFeatures: java.util.List[BEDFeature] = bedReader.iterator ().toList
+    val bedReader = AbstractFeatureReader.getFeatureReader(bed.toAbsolutePath.toString, new BEDCodec(), false)
+    val bedFeatures: java.util.List[BEDFeature] = bedReader.iterator().toList
     bedReader.close()
-    OverlapDetector.create (bedFeatures)
+    OverlapDetector.create(bedFeatures)
   }
 }

--- a/src/main/scala/com/fulcrumgenomics/sv/tools/AggregateSvPileup.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/tools/AggregateSvPileup.scala
@@ -4,7 +4,7 @@ import com.fulcrumgenomics.FgBioDef.{FilePath, PathToBam}
 import com.fulcrumgenomics.bam.api.{QueryType, SamRecord, SamSource}
 import com.fulcrumgenomics.commons.util.LazyLogging
 import com.fulcrumgenomics.sopt.{arg, clp}
-import com.fulcrumgenomics.sv.BreakpointPileup
+import com.fulcrumgenomics.sv.{BreakpointPileup, FgSvDef}
 import com.fulcrumgenomics.sv.cmdline.{ClpGroups, SvTool}
 import com.fulcrumgenomics.sv.tools.AggregateSvPileup.PileupGroup
 import com.fulcrumgenomics.sv.tools.BreakpointCategory.BreakpointCategory
@@ -79,14 +79,7 @@ class AggregateSvPileup
     val samSource: Option[SamSource] = bam.map(SamSource(_))
 
     // Read targets from bed file and build OverlapDetector
-    val targets: Option[OverlapDetector[BEDFeature]] = targetsBed match {
-      case None => None
-      case Some(bed) =>
-        val bedReader = AbstractFeatureReader.getFeatureReader(bed.toAbsolutePath.toString, new BEDCodec(), false)
-        val bedFeatures: java.util.List[BEDFeature] = bedReader.iterator().toList
-        bedReader.close()
-        Some(OverlapDetector.create(bedFeatures))
-    }
+    val targets: Option[OverlapDetector[BEDFeature]] = targetsBed.map(FgSvDef.overlapDetectorFrom)
 
     // Open output writer
     val writer = Metric.writer[AggregatedBreakpointPileup](output)

--- a/src/main/scala/com/fulcrumgenomics/sv/tools/AggregateSvPileup.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/tools/AggregateSvPileup.scala
@@ -4,14 +4,13 @@ import com.fulcrumgenomics.FgBioDef.{FilePath, PathToBam}
 import com.fulcrumgenomics.bam.api.{QueryType, SamRecord, SamSource}
 import com.fulcrumgenomics.commons.util.LazyLogging
 import com.fulcrumgenomics.sopt.{arg, clp}
-import com.fulcrumgenomics.sv.{BreakpointPileup, FgSvDef}
 import com.fulcrumgenomics.sv.cmdline.{ClpGroups, SvTool}
 import com.fulcrumgenomics.sv.tools.AggregateSvPileup.PileupGroup
 import com.fulcrumgenomics.sv.tools.BreakpointCategory.BreakpointCategory
+import com.fulcrumgenomics.sv.{BreakpointPileup, Intervals}
 import com.fulcrumgenomics.util.{Io, Metric}
 import htsjdk.samtools.util.{Interval, OverlapDetector}
-import htsjdk.tribble.bed.{BEDCodec, BEDFeature}
-import htsjdk.tribble.AbstractFeatureReader
+import htsjdk.tribble.bed.BEDFeature
 
 import scala.collection.mutable
 
@@ -79,7 +78,7 @@ class AggregateSvPileup
     val samSource: Option[SamSource] = bam.map(SamSource(_))
 
     // Read targets from bed file and build OverlapDetector
-    val targets: Option[OverlapDetector[BEDFeature]] = targetsBed.map(FgSvDef.overlapDetectorFrom)
+    val targets: Option[OverlapDetector[BEDFeature]] = targetsBed.map(Intervals.overlapDetectorFrom)
 
     // Open output writer
     val writer = Metric.writer[AggregatedBreakpointPileup](output)

--- a/src/main/scala/com/fulcrumgenomics/sv/tools/SvPileup.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/tools/SvPileup.scala
@@ -215,7 +215,7 @@ class SvPileup
 
     breakpoints.foreach { bp =>
       val leftTargets  = targets.map(_.getOverlaps(bp.leftInterval(dict)).map(_.getName).toSeq.sorted.mkString(","))
-      val rightTargets = targets.map(_.getOverlaps(bp.leftInterval(dict)).map(_.getName).toSeq.sorted.mkString(","))
+      val rightTargets = targets.map(_.getOverlaps(bp.rightInterval(dict)).map(_.getName).toSeq.sorted.mkString(","))
       val info         = tracker(bp)
       val metric       = BreakpointPileup(
         id           = info.id.toString,

--- a/src/main/scala/com/fulcrumgenomics/sv/tools/SvPileup.scala
+++ b/src/main/scala/com/fulcrumgenomics/sv/tools/SvPileup.scala
@@ -156,9 +156,9 @@ class SvPileup
             val leftBreakpoint  = ev.breakpoint.leftInterval(source.dict)
             val rightBreakpoint = ev.breakpoint.rightInterval(source.dict)
             targetsBedRequirement match {
-              case TargetBedRequirement.AnnotateOnly    => true
-              case TargetBedRequirement.OverlapAny  => detector.overlapsAny(leftBreakpoint) || detector.overlapsAny(rightBreakpoint)
-              case TargetBedRequirement.OverlapBoth => detector.overlapsAny(leftBreakpoint) && detector.overlapsAny(rightBreakpoint)
+              case TargetBedRequirement.AnnotateOnly => true
+              case TargetBedRequirement.OverlapAny   => detector.overlapsAny(leftBreakpoint) || detector.overlapsAny(rightBreakpoint)
+              case TargetBedRequirement.OverlapBoth  => detector.overlapsAny(leftBreakpoint) && detector.overlapsAny(rightBreakpoint)
             }
           }
         }

--- a/src/test/scala/com/fulcrumgenomics/sv/tools/SvPileupTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/sv/tools/SvPileupTest.scala
@@ -517,16 +517,16 @@ class SvPileupTest extends UnitSpec {
 
     // Annotations only
     {
-      test(allReqs, TargetBedRequirement.AnnotateOnly, Some(leftOnlyBed), bp1.copy(left_target=Some("left")), bp2)
-      test(allReqs, TargetBedRequirement.AnnotateOnly, Some(rightOnlyBed), bp1.copy(right_target=Some("right")), bp2)
-      test(allReqs, TargetBedRequirement.AnnotateOnly, Some(bothBed),  bp1.copy(left_target=Some("left"), right_target=Some("right")), bp2)
+      test(allReqs, TargetBedRequirement.AnnotateOnly, Some(leftOnlyBed), bp1.copy(left_targets=Some("left")), bp2)
+      test(allReqs, TargetBedRequirement.AnnotateOnly, Some(rightOnlyBed), bp1.copy(right_targets=Some("right")), bp2)
+      test(allReqs, TargetBedRequirement.AnnotateOnly, Some(bothBed),  bp1.copy(left_targets=Some("left"), right_targets=Some("right")), bp2)
     }
 
     // OverlapsAny (bp2 not output)
     {
-      test(allReqs, TargetBedRequirement.OverlapAny, Some(leftOnlyBed), bp1.copy(left_target = Some("left")))
-      test(allReqs, TargetBedRequirement.OverlapAny, Some(rightOnlyBed), bp1.copy(right_target = Some("right")))
-      test(allReqs, TargetBedRequirement.OverlapAny, Some(bothBed), bp1.copy(left_target = Some("left"), right_target = Some("right")))
+      test(allReqs, TargetBedRequirement.OverlapAny, Some(leftOnlyBed), bp1.copy(left_targets = Some("left")))
+      test(allReqs, TargetBedRequirement.OverlapAny, Some(rightOnlyBed), bp1.copy(right_targets = Some("right")))
+      test(allReqs, TargetBedRequirement.OverlapAny, Some(bothBed), bp1.copy(left_targets = Some("left"), right_targets = Some("right")))
     }
 
 
@@ -534,7 +534,7 @@ class SvPileupTest extends UnitSpec {
     {
       test(allReqs, TargetBedRequirement.OverlapBoth, Some(leftOnlyBed))
       test(allReqs, TargetBedRequirement.OverlapBoth, Some(rightOnlyBed))
-      test(allReqs, TargetBedRequirement.OverlapBoth, Some(bothBed), bp1.copy(left_target = Some("left"), right_target = Some("right")))
+      test(allReqs, TargetBedRequirement.OverlapBoth, Some(bothBed), bp1.copy(left_targets = Some("left"), right_targets = Some("right")))
     }
   }
 }


### PR DESCRIPTION
The user may provide an optional BED file with `--targets-bed`.  The output breakpoints will be annotated with a comma-delimited list of targets in the BED file (by name) that overlap each side respectively.  Therefore, this changes the output format.

Furthermore, the `--targets-bed-requirement` option can be used to specify that only breakpoints that at least one target (at least one side via `OverlapsAny`, and both sides via `OverlapsBoth`) are written to the output.  In the case of `OverlapsBoth`, each side of a breakpoint does not have to overlap _the same_ target, just that they each independently overlap a target (can be a different target).